### PR TITLE
Update Falco Helm values: adjust grpc, collectors, and remove falcoctl config

### DIFF
--- a/values-local.yaml
+++ b/values-local.yaml
@@ -1,12 +1,6 @@
 falco:
   falco:
     log_level: debug
-    grpc:
-      enabled: false
-    grpc_output:
-      enabled: false
-    config_files:
-      - /etc/falco/config.d/falco.iso8601_timeformat.yaml
   customRules:
     customized-local-rules.yaml: |-
       - list: known_drop_and_execute_containers

--- a/values-subchart-overrides.yaml
+++ b/values-subchart-overrides.yaml
@@ -1,4 +1,7 @@
 falco:
+  collectors:
+    kubernetes:
+      enabled: true
   customRules:
     customized-rules.yaml: |-
       - list: known_drop_and_execute_containers
@@ -81,9 +84,9 @@ falco:
       leastPrivileged: false
   falco:
     grpc:
-      enabled: true
+      enabled: false
     grpc_output:
-      enabled: true
+      enabled: false
     webserver:
       prometheus_metrics_enabled: true
   resources:
@@ -96,9 +99,3 @@ falco:
     create: true
     labels:
       prometheus: cluster-monitoring
-  falcoctl:
-    artifact:
-      follow:
-        enabled: false
-      install:
-        enabled: false


### PR DESCRIPTION
This pull request makes configuration changes to the Falco Helm chart values, mainly focusing on disabling gRPC features and enabling Kubernetes collectors. The changes ensure that gRPC and its output are turned off, while custom rules and Kubernetes event collection are maintained or enabled.

Configuration changes to Falco:

* Disabled gRPC and gRPC output by setting `grpc.enabled` and `grpc_output.enabled` to `false` in both `values-local.yaml` and `values-subchart-overrides.yaml`. [[1]](diffhunk://#diff-be8f9935cfe89dcc01281a7b9708f8ebd5a90b53a01c3ada5be26f2489691f6eL4-L9) [[2]](diffhunk://#diff-a981246ef0b34c87829877293a153bc911135ebea3364dd14f05a0a3ced8a465L84-R89)
* Enabled the Kubernetes collector under `falco.collectors.kubernetes` in `values-subchart-overrides.yaml` to allow Falco to collect Kubernetes events.
* Removed the `falcoctl.artifact.follow.enabled` and `falcoctl.artifact.install.enabled` settings, cleaning up unused configuration.

Custom rules management:

* Maintained or updated custom rules under `customRules` in both values files, ensuring that the list of known drop-and-execute containers is preserved. [[1]](diffhunk://#diff-be8f9935cfe89dcc01281a7b9708f8ebd5a90b53a01c3ada5be26f2489691f6eL4-L9) [[2]](diffhunk://#diff-a981246ef0b34c87829877293a153bc911135ebea3364dd14f05a0a3ced8a465R2-R4)