### PR TITLE
add new exceptions for Falco false positives

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: &name falco
 version: 1.0.0
 dependencies:
-- name: falco
+- name: *name
   version: 8.0.5
   repository: https://falcosecurity.github.io/charts

--- a/values-local.yaml
+++ b/values-local.yaml
@@ -21,4 +21,4 @@ falco:
       memory: 0Mi
     limits:
       cpu: 0m
-      memory: 256Mi
+      memory: 1Gi

--- a/values-subchart-overrides.yaml
+++ b/values-subchart-overrides.yaml
@@ -65,9 +65,7 @@ falco:
           proc.name = calico or
           (
             k8s.ns.name = "postgres" and
-            k8s.pod.name contains "standby-prod-moodle-postgres-cluster" and
-            fd.rip = "10.43.0.1" and
-            fd.rport = 443
+            k8s.pod.name contains "standby-prod-moodle-postgres-cluster"
           ))
       - macro: user_known_stand_streams_redirect_activities
         condition: >
@@ -83,7 +81,7 @@ falco:
       - macro: user_shell_container_exclusions
         condition: >
           (
-            proc.name = "postgres" and
+            proc.pname = "postgres" and
             proc.cmdline contains "wal-e.d/env" and
             k8s.ns.name = "postgres" and
             (
@@ -122,7 +120,8 @@ falco:
         condition: >
           (proc.name = "rkhunter" and
           fd.name = "/etc/shadow") or
-          (fd.name startswith "/etc/pam.d/") 
+          (proc.name = "rkhunter" and
+          fd.name startswith "/etc/pam.d/") 
   driver:
     kind: modern-bpf
     modern_bpf:

--- a/values-subchart-overrides.yaml
+++ b/values-subchart-overrides.yaml
@@ -18,6 +18,7 @@ falco:
             registry.k8s.io/autoscaling/vpa-admission-controller,
             ghcr.io/kyverno/background-controller,
             ghcr.io/kyverno/cleanup-controller,
+            reg.kyverno.io/kyverno/cleanup-controller,
             ghcr.io/kyverno/kyverno,
             ghcr.io/kyverno/reports-controller,
             jenkins/jenkins,
@@ -41,6 +42,8 @@ falco:
             k8s.ns.name = strimzi-operator or
           k8s.pod.name startswith kafka-entity-operator- and
             k8s.ns.name = kafka or
+          k8s.pod.name = harbor-db-0 and
+            k8s.ns.name = harbor or
           k8s.pod.name startswith prometheus-prometheus-operator-kube-p-prometheus- and
             k8s.ns.name = prometheus-operator or
           k8s.ns.name = crossplane-system and
@@ -59,12 +62,18 @@ falco:
             /opt/cni/bin/calico,
             /opt/cni/bin/istio-cni
           ) or
-          proc.name = calico)
+          proc.name = calico or
+          (
+            k8s.ns.name = "postgres" and
+            k8s.pod.name contains "standby-prod-moodle-postgres-cluster" and
+            fd.rip = "10.43.0.1" and
+            fd.rport = 443
+          ))
       - macro: user_known_stand_streams_redirect_activities
         condition: >
           (k8s.pod.name startswith canal- and
             k8s.ns.name = kube-system or
-           k8s.pod.name startswith kured- and
+          k8s.pod.name startswith kured- and
             k8s.ns.name = kured or
           container.image.repository in (
             quay.io/argoproj/argocd,
@@ -73,11 +82,47 @@ falco:
           ))
       - macro: user_shell_container_exclusions
         condition: >
-          (proc.pname=postgres and
-            (proc.cmdline contains "/scripts/restore_command.sh" or
-             proc.cmdline contains "wal-g wal-push") and
+          (
+            proc.name = "postgres" and
             proc.cmdline contains "wal-e.d/env" and
-            k8s.ns.name = postgres)
+            k8s.ns.name = "postgres" and
+            (
+              proc.cmdline contains "/scripts/restore_command.sh" or
+              proc.cmdline contains "wal-g wal-push"
+            )
+          ) or
+          (
+            proc.pname = "postgres" and
+            k8s.pod.name contains "standby-prod-moodle-postgres-cluster" and
+            evt.type = execve and
+            proc.name in ("sh", "bash")
+          ) or
+          (
+            proc.pexepath startswith "/usr/lib/postgresql/" and
+            k8s.ns.name = "postgres" and
+            proc.name in ("sh", "bash")
+          )
+
+      - macro: known_ptrace_procs
+        condition: >
+          (proc.exepath = "/opt/traps/bin/pmd" and
+          proc.name = "InjectionThread")
+
+      - macro: allowed_clear_log_files
+        condition: >
+          (proc.name in ("rkhunter", "cp", "sh") and
+          (fd.name startswith "/var/log/rkhunter" or
+            fd.name startswith "/var/log/dpkg.log" or
+            fd.name contains "/usr/sbin/cron" or
+            fd.name contains "/etc/default/cron" or
+            fd.name contains "/etc/init.d/cron" or
+            fd.name contains "/etc/pam.d/cron"))
+
+      - macro: user_known_read_sensitive_files_activities
+        condition: >
+          (proc.name = "rkhunter" and
+          fd.name = "/etc/shadow") or
+          (fd.name startswith "/etc/pam.d/") 
   driver:
     kind: modern-bpf
     modern_bpf:


### PR DESCRIPTION
added several exception rules for Falco for false positives of the following types:
- Notice Shell spawned by untrusted binary
- Notice Unexpected connection to K8s API Server
- Warning Sensitive file opened for reading by non-trusted program

most of which were triggered by postgres and harbor