### PR TITLE
Remove local memory limits to use default chart values

### DIFF
--- a/values-local.yaml
+++ b/values-local.yaml
@@ -16,9 +16,8 @@ falco:
         override:
           condition: append
   resources:
+    limits:
+      cpu: 0m
     requests:
       cpu: 0m
       memory: 0Mi
-    limits:
-      cpu: 0m
-      memory: 256Mi


### PR DESCRIPTION
This pull request updates the resource configuration for the `falco` deployment, specifically adjusting memory limits in the `values-local.yaml` file.

Resource configuration changes:

* Removed the memory limit (`memory: 256Mi`) and now only sets a CPU limit of `0m` under `resources.limits` for `falco` (`values-local.yaml`).