### PR TITLE
Require manual merge for major and minor updates to falco chart

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,21 @@
         "minor",
         "patch"
       ]
+    },
+    {
+      "description": "Require manual merge for falco chart major/minor bumps, each in its own PR; patch keeps automerging.",
+      "automerge": false,
+      "separateMajorMinor": true,
+      "matchManagers": [
+        "helmv3"
+      ],
+      "matchPackageNames": [
+        "falco"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This pull request updates the Renovate configuration to require manual merges for major and minor updates to the `falco` Helm chart, ensuring these updates are reviewed individually. Patch updates for `falco` will continue to be automerged as before.

Renovate configuration changes:

* Added a rule to require manual merges for major and minor updates to the `falco` package managed by `helmv3`, with each such update in its own pull request. Patch updates remain automerged.