### PR TITLE
add k8s04 config to helm config

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Environments and their rendering configuration are defined in `helm-config.yaml`
 | `sf-k8s01-dev`  | `values-subchart-overrides.yaml`                       |
 | `sf-k8s02-dev`  | `values-subchart-overrides.yaml`                       |
 | `sf-k8s03-dev`  | `values-subchart-overrides.yaml`                       |
+| `sf-k8s04-dev`  | `values-subchart-overrides.yaml`                       |
 | `sf-k8s01-prod` | `values-subchart-overrides.yaml`                       |
 
 Add a new environment by adding an entry under `environments` in `helm-config.yaml`. If the

--- a/README.md
+++ b/README.md
@@ -74,7 +74,12 @@ The version of the `falco` dependency is pinned in `Chart.yaml`. To bump it:
       alpine/helm dependency update
    ```
 
-3. Commit the updated `Chart.yaml`, `Chart.lock`, and the refreshed `charts/` directory together.
+3. Commit the updated `Chart.yaml`.
+
+> [!NOTE]
+> `Chart.lock` and `charts/` are gitignored build artifacts, so only `Chart.yaml` is committed. This also
+> means a stale `charts/` archive is never detected by the test suite — it renders whatever version happens
+> to sit on disk, so refresh it after every `Chart.yaml` change.
 
 See the [Helm docs](https://helm.sh/docs/topics/charts/#chart-dependencies) for more details.
 
@@ -142,7 +147,13 @@ The script:
 ## Testing
 
 Chart behavior is covered by [helm-unittest](https://github.com/helm-unittest/helm-unittest)
-suites in `tests/*_test.yaml`, one per rendered resource. Run the full suite with:
+suites in `tests/*_test.yaml`, one per rendered resource. Between them they assert the modern eBPF driver
+selection and the resulting container privileges, the metrics and Prometheus webserver settings, the
+disabled gRPC servers and the absent gRPC `Service`, the debug log level on local versus the default
+elsewhere, the shared and local-only custom rules files, the k8s-metacollector deployment, the
+`ServiceMonitor` and its Prometheus label, and container resources for local versus every other cluster.
+
+Run the full suite with:
 
 ```sh
  docker run \
@@ -154,6 +165,13 @@ suites in `tests/*_test.yaml`, one per rendered resource. Run the full suite wit
    -w /apps \
    helmunittest/helm-unittest .
 ```
+
+Append `-u` to the same command to rewrite the one daemonset snapshot after an intentional change.
+
+> [!NOTE]
+> `tests/__snapshot__/` is gitignored and rebuilt locally. The snapshot catches broad side effects, but it
+> proves nothing on its own — refreshing it silences a regression as easily as it records an intended
+> change. Anything that must not change is covered by a direct assertion instead.
 
 ## Running The GitHub Pipeline Locally
 
@@ -176,6 +194,18 @@ is needed.
 [extra Kind mounts required](https://falco.org/docs/getting-started/third-party/learning/#kind)
 are already added in the
 [SteadOps-Steadies-K8s-Workplace](https://gitea.cloud01.intern.steadforce.com/Playground/SteadOps-Steadies-K8s-Workplace).
+
+## Privileged Driver
+
+`values-subchart-overrides.yaml` sets `driver.modernEbpf.leastPrivileged: false`, so the falco container
+runs with `privileged: true` rather than the narrower `BPF`, `SYS_RESOURCE`, `PERFMON` and `SYS_PTRACE`
+capability set.
+
+> [!WARNING]
+> This is a deliberate trade-off, not an oversight: the least-privileged mode restricts what the modern
+> eBPF driver can observe. Flipping it changes the container's privilege level cluster-wide, so treat it as
+> a security decision. `tests/falco-daemonset_test.yaml` asserts the resulting `securityContext` so neither
+> direction changes silently.
 
 ## The Falco Driver
 

--- a/helm-config.yaml
+++ b/helm-config.yaml
@@ -19,4 +19,5 @@ environments:
     - values-subchart-overrides.yaml
   sf-k8s02-dev: *environment
   sf-k8s03-dev: *environment
+  sf-k8s04-dev: *environment
   sf-k8s01-prod: *environment

--- a/tests/falco-configmap_test.yaml
+++ b/tests/falco-configmap_test.yaml
@@ -43,4 +43,9 @@ tests:
   asserts:
   - matchRegex:
       path: *falcoYamlPath
-      pattern: "(?m)^log_level: debug$"
+      pattern: &debugLogLevelPattern "(?m)^log_level: debug$"
+- it: keeps the default log level on all other clusters
+  asserts:
+  - notMatchRegex:
+      path: *falcoYamlPath
+      pattern: *debugLogLevelPattern

--- a/tests/falco-daemonset_test.yaml
+++ b/tests/falco-daemonset_test.yaml
@@ -47,3 +47,16 @@ tests:
   - matchRegex:
       path: *memoryRequestsPath
       pattern: *nonZeroMemoryPattern
+# driver.modernEbpf.leastPrivileged is set to false in values-subchart-overrides.yaml,
+# which is what makes the falco container run fully privileged instead of with the
+# BPF/SYS_RESOURCE/PERFMON/SYS_PTRACE capability set.
+- it: runs the falco container privileged rather than with the least-privileged capability set
+  templates: *daemonsetTemplate
+  values:
+  - ../values-subchart-overrides.yaml
+  asserts:
+  - equal:
+      path: spec.template.spec.containers[?(@.name == "falco")].securityContext.privileged
+      value: true
+  - notExists:
+      path: spec.template.spec.containers[?(@.name == "falco")].securityContext.capabilities


### PR DESCRIPTION
Title: Add sf-k8s04-dev and pin the falco container privilege level

---

## What

Two commits:

1. **`add k8s04 config to helm config`** — registers the `sf-k8s04-dev` environment.
2. **`improve test coverage, update readme`** — covers a security-relevant override that had no
   assertion, adds the missing non-local counterpart for the log level, and corrects the README.

## sf-k8s04-dev

A single line in `helm-config.yaml`:

```yaml
sf-k8s04-dev: *environment
```

The cluster reuses the shared `&environment` anchor, so it inherits the same `apis` list and the
same single value file (`values-subchart-overrides.yaml`) as every other non-local cluster. No
per-cluster value file is needed, and the existing "all other clusters" cases already cover it.
The README environments table was updated in the same commit.

## Test coverage

**`driver.modernEbpf.leastPrivileged: false` had no assertion anywhere.** That override is what
makes the falco container run with `privileged: true` instead of the narrower `BPF`,
`SYS_RESOURCE`, `PERFMON`, `SYS_PTRACE` capability set — verified by rendering the daemonset both
ways. Nothing would have caught a flip in either direction: toward least-privileged, which
restricts what the modern eBPF driver can observe, or away from it, which silently escalates the
container. `tests/falco-daemonset_test.yaml` now asserts `securityContext.privileged` is `true`
and that the capability set is absent.

**Log level had no non-local counterpart.** The suite asserted `log_level: debug` for local but
never that other clusters keep the default, so dropping the local override would have been
invisible from the non-local side. Added, reusing the local pattern via an anchor.

## README

- **Corrects a wrong instruction.** The chart-bump steps said to commit `Chart.yaml`,
  `Chart.lock` and `charts/` together, but `.gitignore` excludes both `/Chart.lock` and
  `/charts/`. Only `Chart.yaml` is committed. Added the corollary that a stale `charts/` archive
  is never detected by the suite, since it renders whatever version sits on disk.
- **New "Privileged Driver" section** documenting the `leastPrivileged: false` trade-off as a
  security decision rather than an oversight, and pointing at the test that pins it.
- Fills in what the suites actually assert, and documents the snapshot refresh plus the caveat
  that refreshing a snapshot silences a regression as easily as it records an intended change.

## Testing

`helmunittest/helm-unittest .` -> **6 suites, 16 tests, 1 snapshot, all passing**
(from 14 tests).

The anchor audit reports no unreferenced anchors and no unresolved aliases. The existing suites
were already well anchored, so no refactor was needed — the one anchor I introduced and left
unreferenced was removed again.
